### PR TITLE
hotfix: gst_espeak_get_property fix PROP_PITCH and PROP_RATE

### DIFF
--- a/src/gstespeak.c
+++ b/src/gstespeak.c
@@ -230,10 +230,10 @@ gst_espeak_get_property (GObject * object, guint prop_id,
         g_value_set_string (value, self->text);
         break;
     case PROP_PITCH:
-        g_value_set_uint (value, self->pitch);
+        g_value_set_int (value, self->pitch);
         break;
     case PROP_RATE:
-        g_value_set_uint (value, self->rate);
+        g_value_set_int (value, self->rate);
         break;
     case PROP_VOICE:
         g_value_set_string (value, self->voice);


### PR DESCRIPTION
Fix w/o all of the `atom editor` stylistic changes, to keep the code as close as possible to the original, for debugging purposes. This PR will replace https://github.com/bossjones/bossjones-gst-plugins-espeak-0-4-0/pull/1
